### PR TITLE
Fix image metadata

### DIFF
--- a/keyboard-symbol.py
+++ b/keyboard-symbol.py
@@ -6,8 +6,8 @@
 # <bitbar.author>Đinh Quang Hiếu</bitbar.author>
 # <bitbar.author.github>dqhieu</bitbar.author.github>
 # <bitbar.desc>This plugin displays a menu of keyboard symbol</bitbar.desc>
-# <bitbar.image></bitbar.image>
-# <bitbar.dependencies>https://raw.githubusercontent.com/dqhieu/keyboard-symbol/master/demo.png</bitbar.dependencies>
+# <bitbar.image>https://raw.githubusercontent.com/dqhieu/keyboard-symbol/master/demo.png</bitbar.image>
+# <bitbar.dependencies></bitbar.dependencies>
 
 print '⌨️'
 print '---'


### PR DESCRIPTION
Moved the demo image into the `bitbar.image` tag so it displays correctly on the plugin website.